### PR TITLE
Add command-line arguments and freezing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,116 @@
+# Experiment results
+results/
+
+# IDE folders
+.idea
+.vscode
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+# *.manifest
+# *.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ MANIFEST
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
-# *.manifest
+*.manifest
 # *.spec
 
 # Installer logs

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ pip install -e .
 ```
 **Warning**: nfb requires you install some outdated versions of packages. Consider installing nfb in a virtual enviroment, using tools such as venv or conda.
 
+### Freezing
+NFB supports building as an executable, using the `pyinstaller` module. To use it, first install nfb with `freeze` addon:
+```
+pip install -e .[freeze]
+```
+Then build the executable from the included spec file (this might take some time):
+```
+pyinstaller freeze.spec
+```
+The executable can then be found in the `dist` folder.
+
 ## Running the experiment designer
 If you are using `conda` as your virtual environment provider, don't forget to create and activate a virtual environment:
 ```

--- a/README.md
+++ b/README.md
@@ -4,13 +4,29 @@
 ## Installation
 Prerequisites: [python](https://www.python.org/), [git](https://git-scm.com/), optionally [conda](https://docs.conda.io/en/latest/miniconda.html).
 
-Clone this repository and install the package in editable mode by running:
+**Warning:** NFB Studio requires you install some outdated versions of packages. Consider installing it in a virtual enviroment, using tools such as venv or conda. For example, if using conda, create and activate a new environment by running these commands first:
+```
+conda create -n nfb python pip
+conda activate nfb
+```
+
+Regardless of whether or not you are using a virtual environment, clone this repository and install the package in editable mode by running:
 ```
 git clone https://github.com/nikolaims/nfb
 cd nfb
 pip install -e .
 ```
-**Warning**: nfb requires you install some outdated versions of packages. Consider installing nfb in a virtual enviroment, using tools such as venv or conda.
+
+## Running the experiment designer
+After installation, NFB Lab can be run from anywhere by using this command (when using a virtual environment, it has to be active):
+```
+pynfb
+```
+Or from the folder you installed it in:
+```
+python pynfb/main.py
+```
+If you need to use NFB Lab without a console, or run it from anywhere and distribute it, the best option is to freeze it into an executable.
 
 ### Freezing
 NFB supports building as an executable, using the `pyinstaller` module. To use it, first install nfb with `freeze` addon:
@@ -23,21 +39,10 @@ pyinstaller freeze.spec
 ```
 The executable can then be found in the `dist` folder.
 
-## Running the experiment designer
-If you are using `conda` as your virtual environment provider, don't forget to create and activate a virtual environment:
-```
-conda create -n nfb python pip
-conda activate nfb
-```
-Run the experiment designer:
-```
-python pynfb/main.py
-```
-
 ### Commandline arguments
 NFB supports commandline arguments to streamline opening and running experiments:
 ```
-usage: main.py [-h] [-x] [file]
+usage: pynfb [-h] [-x] [file]
 
 positional arguments:
   file           open an xml experiment file when launched (optional)
@@ -46,14 +51,15 @@ optional arguments:
   -h, --help     show this help message and exit
   -x, --execute  run the experiment without configuring (requires file to be specified)
 ```
-For example, to open an experiment file from command line, specify the path to it like so:
+For example, to open an XML file with an experiment that you designed from command line, specify the path to it like so:
 ```
-python pynfb/main.py experiment-file.xml
+python pynfb/main.py your-experiment-file.xml
 ```
 To run the experiment without configuring, use the `-x` or `--execute` option:
 ```
-python pynfb/main.py -x experiment-file.xml
+python pynfb/main.py -x your-experiment-file.xml
 ```
+**Note:** The same command-line options are available for the `pynfb` executable, but since the console output is hidden, if you make a mistake the application will just not start.
 
 ## Acknowledgements
 This work was supported by the [Center for Bioelectric Interfaces](https://bioelectric.hse.ru/en/) of the Institute for Cognitive Neuroscience of the National Research University Higher School of Economics, RF Government grant, ag. No. 14.641.31.0003.

--- a/README.md
+++ b/README.md
@@ -23,5 +23,26 @@ Run the experiment designer:
 python pynfb/main.py
 ```
 
+### Commandline arguments
+NFB supports commandline arguments to streamline opening and running experiments:
+```
+usage: main.py [-h] [-x] [file]
+
+positional arguments:
+  file           open an xml experiment file when launched (optional)
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -x, --execute  run the experiment without configuring (requires file to be specified)
+```
+For example, to open an experiment file from command line, specify the path to it like so:
+```
+python pynfb/main.py experiment-file.xml
+```
+To run the experiment without configuring, use the `-x` or `--execute` option:
+```
+python pynfb/main.py -x experiment-file.xml
+```
+
 ## Acknowledgements
 This work was supported by the [Center for Bioelectric Interfaces](https://bioelectric.hse.ru/en/) of the Institute for Cognitive Neuroscience of the National Research University Higher School of Economics, RF Government grant, ag. No. 14.641.31.0003.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
-## NFB Lab 
-*NFB Lab* is a software that allows you to configure the design and conduct an experiment in real-time EEG/MEG paradigm
-### Setup python interpreter
-1. Download and install [miniconda](https://conda.io/miniconda.html). Optionally create new environment.
-2. Install conda-packages by command:
-```
-conda install h5py pyqt pyopengl pyqtgraph seaborn scikit-learn sympy
-```
-3. Install pip-packages by command:
-```
-pip install mne pylsl
-```
-### Running NFB Lab *experiment design module*
-Run `main.py` by command 
-```
-python pynfb\main.py`
-```
-Where `python` interpreter is from installed miniconda folder
+# NFB Lab 
+*NFB Lab* allows you to configure the design and conduct an experiment in real-time EEG/MEG paradigm.
 
-## PyQt4 stable version
-[https://github.com/nikolaims/nfb/tree/pyqt4-stable](https://github.com/nikolaims/nfb/tree/pyqt4-stable)
+## Installation
+Prerequisites: [python](https://www.python.org/), [git](https://git-scm.com/), optionally [conda](https://docs.conda.io/en/latest/miniconda.html).
 
+Clone this repository and install the package in editable mode by running:
+```
+git clone https://github.com/nikolaims/nfb
+cd nfb
+pip install -e .
+```
+**Warning**: nfb requires you install some outdated versions of packages. Consider installing nfb in a virtual enviroment, using tools such as venv or conda.
+
+## Running the experiment designer
+If you are using `conda` as your virtual environment provider, don't forget to create and activate a virtual environment:
+```
+conda create -n nfb python pip
+conda activate nfb
+```
+Run the experiment designer:
+```
+python pynfb/main.py
+```
 
 ## Acknowledgements
 This work was supported by the [Center for Bioelectric Interfaces](https://bioelectric.hse.ru/en/) of the Institute for Cognitive Neuroscience of the National Research University Higher School of Economics, RF Government grant, ag. No. 14.641.31.0003.

--- a/freeze.spec
+++ b/freeze.spec
@@ -1,0 +1,57 @@
+# -*- mode: python ; coding: utf-8 -*-
+# NOTE: pyinstaller 4.0 does not work. Works with 3.6
+# NOTE: to build this matplotlib needs to be downgraded. Works with 3.2.2
+import sys
+from distutils.sysconfig import get_python_lib
+
+sys.setrecursionlimit(5000)
+block_cipher = None
+
+
+a = Analysis(
+    ['pynfb\\main.py'],
+    pathex=['D:\\Files\\Develop\\nfb'],
+    binaries=[],
+    datas=[
+        (get_python_lib()+"/pylsl/lib", "pylsl/lib"),
+        (get_python_lib()+"/mne/channels/data", "mne/channels/data"),
+        ("pynfb/static/imag", "pynfb/static/imag"),
+    ],
+    hiddenimports=[
+        "scipy.special.cython_special",
+        "sklearn.neighbors._typedefs",
+        "sklearn.neighbors._quad_tree",
+        "sklearn.utils._cython_blas",
+        "sklearn.tree._utils"
+    ],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False
+)
+
+pyz = PYZ(
+    a.pure,
+    a.zipped_data,
+    cipher=block_cipher
+)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='pynfb',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True
+)

--- a/pynfb/main.py
+++ b/pynfb/main.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import argparse
+import multiprocessing
 import matplotlib
 matplotlib.use('TkAgg')
 full_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__))+'/..')
@@ -71,6 +72,7 @@ def except_hook(cls, exception, traceback):
     sys.__excepthook__(cls, exception, traceback)
 
 def main():
+    multiprocessing.freeze_support()  # Support running nfb in frozen mode (i.e. as an executable)
     sys.excepthook = except_hook
 
     # Parse and act upon commandline arguments

--- a/pynfb/main.py
+++ b/pynfb/main.py
@@ -93,12 +93,14 @@ def main():
         # If "Execute" was specified, run the experiment immediately
         params = xml_file_to_params(args.file)
         ex = Experiment(app, params)
-    elif args.file:
-        # If "file" was specified, open the experiment file right away
+    else:
         main_window = TheMainWindow(app)
-        params = xml_file_to_params(args.file)
-        main_window.widget.params = params
-        main_window.widget.reset_parameters()
+
+        if args.file:
+            # If "file" was specified, open the experiment file right away
+            params = xml_file_to_params(args.file)
+            main_window.widget.params = params
+            main_window.widget.reset_parameters()
 
     sys.exit(app.exec_())
 

--- a/pynfb/main.py
+++ b/pynfb/main.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import argparse
 import matplotlib
 matplotlib.use('TkAgg')
 full_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__))+'/..')
@@ -71,8 +72,31 @@ def except_hook(cls, exception, traceback):
 
 def main():
     sys.excepthook = except_hook
+
+    # Parse and act upon commandline arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", nargs="?", help="open an xml experiment file when launched (optional)")
+    parser.add_argument("-x", "--execute", action="store_true", help="run the experiment without configuring (requires file to be specified)")
+    args = parser.parse_args()
+
+    if args.file is None and args.execute:
+        print("Could not execute the experiment without configuring because file argument was not specified")
+        parser.print_help()
+        sys.exit(1)
+
     app = QtWidgets.QApplication(sys.argv)
     ex = TheMainWindow(app)
+
+    # If "file" was specified, open the experiment file right away
+    if args.file:
+        params = xml_file_to_params(args.file)
+        ex.widget.params = params
+        ex.widget.reset_parameters()
+    
+    # If "Execute" was specified, run the experiment immediately
+    if args.execute:
+        ex.widget.onClicked()
+
     sys.exit(app.exec_())
 
 

--- a/pynfb/main.py
+++ b/pynfb/main.py
@@ -10,6 +10,7 @@ STATIC_PATH = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + '/s
 print(full_path)
 sys.path.insert(0, full_path)
 from pynfb.settings_widget import SettingsWidget
+from pynfb.experiment import Experiment
 from PyQt5 import QtGui, QtWidgets
 import sys
 from pynfb.serializers.xml_ import *
@@ -87,17 +88,17 @@ def main():
         sys.exit(1)
 
     app = QtWidgets.QApplication(sys.argv)
-    ex = TheMainWindow(app)
 
-    # If "file" was specified, open the experiment file right away
-    if args.file:
-        params = xml_file_to_params(args.file)
-        ex.widget.params = params
-        ex.widget.reset_parameters()
-    
-    # If "Execute" was specified, run the experiment immediately
     if args.execute:
-        ex.widget.onClicked()
+        # If "Execute" was specified, run the experiment immediately
+        params = xml_file_to_params(args.file)
+        ex = Experiment(app, params)
+    elif args.file:
+        # If "file" was specified, open the experiment file right away
+        main_window = TheMainWindow(app)
+        params = xml_file_to_params(args.file)
+        main_window.widget.params = params
+        main_window.widget.reset_parameters()
 
     sys.exit(app.exec_())
 

--- a/pynfb/setup.py
+++ b/pynfb/setup.py
@@ -1,8 +1,0 @@
-from cx_Freeze import setup, Executable
-
-setup(
-    name = "pynfb",
-    version = "0.1",
-    description = "Python NFB",
-    executables = [Executable("main.py")]
-)

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ extras_require = {
 }
 
 package_data = {
-    "pynfb": ["static/*"]
+    "pynfb": ["static/imag/*"]
 }
 
 entry_points = {
-    "console_scripts": ["pynfb=pynfb.main:main"]
+    "gui_scripts": ["pynfb=pynfb.main:main"]
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ extras_require = {
     "freeze":  ["pyinstaller==3.6"]
 }
 
+package_data = {
+    "pynfb": ["static/*"]
+}
+
 entry_points = {
     "console_scripts": ["pynfb=pynfb.main:main"]
 }
@@ -33,4 +37,5 @@ setup(
     extras_require=extras_require,
     entry_points=entry_points,
     packages=find_packages(),
+    package_data=package_data,
 )

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,13 @@ install_requires = [
     "scikit-learn",
     "sympy",
     "mne==0.12",
-    "pylsl"
+    "pylsl",
+    "matplotlib==3.2.2",
 ]
+
+extras_require = {
+    "freeze":  ["pyinstaller==3.6"]
+}
 
 setup(
     name="nfb",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-"""Setup script for nfb package.
-Warning: nfb requires you install some outdated versions of packages. Consider installing nfb in a virtual enviroment,
-using tools such as venv or conda.
+"""Setup script for pynfb package.
+Warning: pynfb requires you install some outdated versions of packages. Consider installing pynfb in a virtual
+enviroment, using tools such as venv or conda.
 """
 from setuptools import setup
 
@@ -22,8 +22,9 @@ extras_require = {
 }
 
 setup(
-    name="nfb",
+    name="pynfb",
     version="0.1",
     description="Conduct experiments in real-time EEG/MEG paradigm",
-    install_requires=install_requires
+    install_requires=install_requires,
+    extras_require=extras_require
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+"""Setup script for nfb package.
+Warning: nfb requires you install some outdated versions of packages. Consider installing nfb in a virtual enviroment,
+using tools such as venv or conda.
+"""
+from setuptools import setup
+
+install_requires = [
+    "h5py",
+    "pyqt5",
+    "pyopengl",
+    "pyqtgraph",
+    "seaborn",
+    "scikit-learn",
+    "sympy",
+    "mne==0.12",
+    "pylsl"
+]
+
+setup(
+    name="nfb",
+    description="Conduct experiments in real-time EEG/MEG paradigm",
+    install_requires=install_requires
+)

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,15 @@ extras_require = {
     "freeze":  ["pyinstaller==3.6"]
 }
 
+entry_points = {
+    "console_scripts": ["pynfb=pynfb.main:main"]
+}
+
 setup(
     name="pynfb",
     version="0.1",
     description="Conduct experiments in real-time EEG/MEG paradigm",
     install_requires=install_requires,
-    extras_require=extras_require
+    extras_require=extras_require,
+    entry_points=entry_points,
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_requires = [
 
 setup(
     name="nfb",
+    version="0.1",
     description="Conduct experiments in real-time EEG/MEG paradigm",
     install_requires=install_requires
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 Warning: pynfb requires you install some outdated versions of packages. Consider installing pynfb in a virtual
 enviroment, using tools such as venv or conda.
 """
-from setuptools import setup
+from setuptools import setup, find_packages
 
 install_requires = [
     "h5py",
@@ -32,4 +32,5 @@ setup(
     install_requires=install_requires,
     extras_require=extras_require,
     entry_points=entry_points,
+    packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     "seaborn",
     "scikit-learn",
     "sympy",
-    "mne==0.12",
+    "mne==0.14.1",
     "pylsl",
     "matplotlib==3.2.2",
 ]


### PR DESCRIPTION
Add command-line arguments, such as `-x` to run the experiment without configuring, and add support for building executables with `pyinstaller`. Improve README.