### PR TITLE
Sep-oct updates to pynfb

### DIFF
--- a/freeze.spec
+++ b/freeze.spec
@@ -1,21 +1,30 @@
-# -*- mode: python ; coding: utf-8 -*-
-# NOTE: pyinstaller 4.0 does not work. Works with 3.6
-# NOTE: to build this matplotlib needs to be downgraded. Works with 3.2.2
+#-*-mode:python;coding:utf-8-*-
 import sys
-from distutils.sysconfig import get_python_lib
+import os
+from importlib.util import find_spec
 
 sys.setrecursionlimit(5000)
 block_cipher = None
 
+def module_dir(module_name):
+    """Return module's root directory.
+    If the module does not have a directory (it is a single file) then return None.
+    """
+    module_origin = find_spec(module_name).origin
+    if os.path.basename(module_origin) == "__init__.py":
+        return os.path.dirname(module_origin)
+    return None
+
 
 a = Analysis(
-    ['pynfb\\main.py'],
-    pathex=['D:\\Files\\Develop\\nfb'],
+    ['pynfb/main.py'],
+    pathex=[],
     binaries=[],
     datas=[
-        (get_python_lib()+"/pylsl/lib", "pylsl/lib"),
-        (get_python_lib()+"/mne/channels/data", "mne/channels/data"),
-        ("pynfb/static/imag", "pynfb/static/imag"),
+        (module_dir("pylsl") + "/lib", "pylsl/lib"),
+        (module_dir("mne") + "/channels/data", "mne/channels/data"),
+        (module_dir("matplotlib") + "/mpl-data", "matplotlib/mpl-data"),
+        (module_dir("pynfb") + "/static/imag", "pynfb/static/imag"),
     ],
     hiddenimports=[
         "scipy.special.cython_special",
@@ -32,13 +41,13 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False
 )
-
+		
 pyz = PYZ(
     a.pure,
     a.zipped_data,
     cipher=block_cipher
 )
-
+			
 exe = EXE(
     pyz,
     a.scripts,

--- a/mu_settings.xml
+++ b/mu_settings.xml
@@ -37,7 +37,7 @@
 			<fDuration>20</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Расслабьтесь. Закройте глаза.</cString>
+			<cString>Р Р°СЃСЃР»Р°Р±СЊС‚РµСЃСЊ. Р—Р°РєСЂРѕР№С‚Рµ РіР»Р°Р·Р°.</cString>
 			<bUseExtraMessage>0</bUseExtraMessage>
 			<cString2>+</cString2>
 			<fBlinkDurationMs>50</fBlinkDurationMs>
@@ -65,7 +65,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Вращайте только ПРАВОЙ кистью</cString>
+			<cString>Р’СЂР°С‰Р°Р№С‚Рµ С‚РѕР»СЊРєРѕ РџР РђР’РћР™ РєРёСЃС‚СЊСЋ</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -149,7 +149,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Можно отдохнуть</cString>
+			<cString>РњРѕР¶РЅРѕ РѕС‚РґРѕС…РЅСѓС‚СЊ</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -177,7 +177,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Вращайте только ЛЕВОЙ кистью</cString>
+			<cString>Р’СЂР°С‰Р°Р№С‚Рµ С‚РѕР»СЊРєРѕ Р›Р•Р’РћР™ РєРёСЃС‚СЊСЋ</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -205,7 +205,7 @@
 			<fDuration>20</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Откройте глаза, сидите спокойно</cString>
+			<cString>РћС‚РєСЂРѕР№С‚Рµ РіР»Р°Р·Р°, СЃРёРґРёС‚Рµ СЃРїРѕРєРѕР№РЅРѕ</cString>
 			<bUseExtraMessage>0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50</fBlinkDurationMs>
@@ -261,7 +261,7 @@
 			<fDuration>60.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Вращайте рукой</cString>
+			<cString>Р’СЂР°С‰Р°Р№С‚Рµ СЂСѓРєРѕР№</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>

--- a/pynfb/__init__.py
+++ b/pynfb/__init__.py
@@ -1,2 +1,8 @@
 import os
+from importlib import import_module
 STATIC_PATH = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + '/static')
+
+# pylsl has a dll order problem with kiwisolver (which is used by matplotlib). If kiwisolver is first imported before
+# pylsl, pylsl will not find any streams. Import this package (pynfb) in your entry point to work around the problem.
+import_module("pylsl")
+import_module("kiwisolver")

--- a/pynfb/bci_mu.xml
+++ b/pynfb/bci_mu.xml
@@ -51,7 +51,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Расслабьтесь. Закройте глаза.</cString>
+			<cString>Р Р°СЃСЃР»Р°Р±СЊС‚РµСЃСЊ. Р—Р°РєСЂРѕР№С‚Рµ РіР»Р°Р·Р°.</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2>+</cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -81,7 +81,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Вращайте только ПРАВОЙ кистью</cString>
+			<cString>Р’СЂР°С‰Р°Р№С‚Рµ С‚РѕР»СЊРєРѕ РџР РђР’РћР™ РєРёСЃС‚СЊСЋ</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -171,7 +171,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Можно отдохнуть</cString>
+			<cString>РњРѕР¶РЅРѕ РѕС‚РґРѕС…РЅСѓС‚СЊ</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -201,7 +201,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Вращайте только ЛЕВОЙ кистью</cString>
+			<cString>Р’СЂР°С‰Р°Р№С‚Рµ С‚РѕР»СЊРєРѕ Р›Р•Р’РћР™ РєРёСЃС‚СЊСЋ</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -231,7 +231,7 @@
 			<fDuration>20.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Откройте глаза, сидите спокойно</cString>
+			<cString>РћС‚РєСЂРѕР№С‚Рµ РіР»Р°Р·Р°, СЃРёРґРёС‚Рµ СЃРїРѕРєРѕР№РЅРѕ</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>
@@ -291,7 +291,7 @@
 			<fDuration>60.0</fDuration>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Вращайте рукой</cString>
+			<cString>Р’СЂР°С‰Р°Р№С‚Рµ СЂСѓРєРѕР№</cString>
 			<bUseExtraMessage>0.0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50.0</fBlinkDurationMs>

--- a/pynfb/experiment.py
+++ b/pynfb/experiment.py
@@ -412,7 +412,7 @@ class Experiment():
                         self.signals,
                         text=protocol['cString'] if protocol['cString'] != '' else 'Relax',
                         half_time_text=protocol['cString2'] if bool(protocol['bUseExtraMessage']) else None,
-                        **kwargs
+                        voiceover=protocol['bVoiceover'], **kwargs
                     ))
             elif protocol['sFb_type'] in ['Feedback', 'CircleFeedback']:
                 self.protocols.append(

--- a/pynfb/inlets/ftbuffer_inlet.py
+++ b/pynfb/inlets/ftbuffer_inlet.py
@@ -38,7 +38,7 @@ class FieldTripBufferInlet:
         pass
 
     def save_info(self, file):
-        with open(file, 'w') as f:
+        with open(file, 'w', encoding="utf-8") as f:
             f.write(str(self.ftc.getHeader()))
 
     def info_as_xml(self):

--- a/pynfb/inlets/lsl_inlet.py
+++ b/pynfb/inlets/lsl_inlet.py
@@ -53,7 +53,7 @@ class LSLInlet:
         pass
 
     def save_info(self, file):
-        with open(file, 'w') as f:
+        with open(file, 'w', encoding="utf-8") as f:
             f.write(self.info_as_xml())
 
     def info_as_xml(self):

--- a/pynfb/inlets/lsl_inlet_n_channels.py
+++ b/pynfb/inlets/lsl_inlet_n_channels.py
@@ -34,7 +34,7 @@ class LSLInlet:
         pass
 
     def save_info(self, file):
-        with open(file, 'w') as f:
+        with open(file, 'w', encoding="utf-8") as f:
             f.write(self.inlet.info().as_xml())
 
     def get_frequency(self):

--- a/pynfb/main.py
+++ b/pynfb/main.py
@@ -2,6 +2,8 @@ import sys
 import os
 import argparse
 import multiprocessing
+
+import pynfb
 import matplotlib
 matplotlib.use('TkAgg')
 full_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__))+'/..')

--- a/pynfb/main.py
+++ b/pynfb/main.py
@@ -69,13 +69,8 @@ class TheMainWindow(QtWidgets.QMainWindow):
         #print(self.widget.params)
         params_to_xml_file(self.widget.params, fname)
 
-def except_hook(cls, exception, traceback):
-    sys.__excepthook__(cls, exception, traceback)
 
 def main():
-    multiprocessing.freeze_support()  # Support running nfb in frozen mode (i.e. as an executable)
-    sys.excepthook = except_hook
-
     # Parse and act upon commandline arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("file", nargs="?", help="open an xml experiment file when launched (optional)")
@@ -87,23 +82,31 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    app = QtWidgets.QApplication(sys.argv)
-
     if args.execute:
         # If "Execute" was specified, run the experiment immediately
-        params = xml_file_to_params(args.file)
-        ex = Experiment(app, params)
-    else:
-        main_window = TheMainWindow(app)
+        sys.exit(run(args.file))
 
-        if args.file:
-            # If "file" was specified, open the experiment file right away
-            params = xml_file_to_params(args.file)
-            main_window.widget.params = params
-            main_window.widget.reset_parameters()
+    app = QtWidgets.QApplication(sys.argv)
+    main_window = TheMainWindow(app)
+
+    if args.file:
+        # If "file" was specified, open the experiment file right away
+        params = xml_file_to_params(args.file)
+        main_window.widget.params = params
+        main_window.widget.reset_parameters()
 
     sys.exit(app.exec_())
 
 
+def run(path):
+    app = QtWidgets.QApplication(sys.argv)
+
+    params = xml_file_to_params(path)
+    ex = Experiment(app, params)
+
+    return app.exec_()
+
+
 if __name__ == '__main__':
+    multiprocessing.freeze_support()  # Support running nfb in frozen mode (i.e. as an executable)
     main()

--- a/pynfb/outlets/neurotlon_state_server.py
+++ b/pynfb/outlets/neurotlon_state_server.py
@@ -19,7 +19,7 @@ class testHTTPServer_RequestHandler(BaseHTTPRequestHandler):
             self.send_header('Content-type', 'application/json')
             self.send_header('Access-Control-Allow-Origin', '*')
             self.end_headers()
-            with open("../../bci_current_state.pkl", "r") as fp:
+            with open("../../bci_current_state.pkl", "r", encoding="utf-8") as fp:
                 state = float(fp.read())
             # Send message back to client
             state = 1 if state > 6000 else 2

--- a/pynfb/outlets/signals_outlet.py
+++ b/pynfb/outlets/signals_outlet.py
@@ -22,7 +22,7 @@ class SignalsOutlet:
 
     def push_chunk(self, data, n=1):
         self.outlet.push_chunk(data)
-        # with open("../bci_current_state.pkl", "w") as fp:
+        # with open("../bci_current_state.pkl", "w", encoding="utf-8") as fp:
         #    fp.write(str(np.array(data)[:, 0].mean()))
 
 

--- a/pynfb/postprocessing/alpha_ica.py
+++ b/pynfb/postprocessing/alpha_ica.py
@@ -18,7 +18,7 @@ mock = False
 
 
 dir_ = 'D:\\alpha'
-with open(dir_ + '\\info.json', 'r') as f:
+with open(dir_ + '\\info.json', 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 subj = 0

--- a/pynfb/postprocessing/bci_mu_bci.py
+++ b/pynfb/postprocessing/bci_mu_bci.py
@@ -45,7 +45,7 @@ mock = False
 
 
 dir_ = r'D:\bci_nfb_bci\bci_nfb_bci'
-with open(dir_ + '\\info.json', 'r') as f:
+with open(dir_ + '\\info.json', 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 subj = 0

--- a/pynfb/postprocessing/bci_mu_bci_metrics.py
+++ b/pynfb/postprocessing/bci_mu_bci_metrics.py
@@ -15,7 +15,7 @@ from scipy import stats
 from pynfb.signals.bci import BCISignal
 
 dir_ = r'D:\bci_nfb_bci\bci_nfb_bci'
-with open(dir_ + '\\info_mock.json', 'r') as f:
+with open(dir_ + '\\info_mock.json', 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 def drop_outliers(x, threshold=0.00005, window=500):

--- a/pynfb/postprocessing/bci_munfb_bci/stats_slopes.py
+++ b/pynfb/postprocessing/bci_munfb_bci/stats_slopes.py
@@ -9,7 +9,7 @@ work_dir = r'C:\Users\Nikolai\Desktop\bci_nfb_bci\bci_nfb_bci'
 
 def open_desc(group='Real'):
     desc_file = 'info_mock.json' if group == 'Mock' else 'info.json'
-    with open('{}/{}'.format(work_dir, desc_file)) as f:
+    with open('{}/{}'.format(work_dir, desc_file), encoding="utf-8") as f:
         desc = json.loads(f.read())
     return desc
 

--- a/pynfb/postprocessing/mne_raw.py
+++ b/pynfb/postprocessing/mne_raw.py
@@ -27,7 +27,7 @@ def add_data_simple(odict, name, x, info):
 settings_file = 'D:\\vnd_spbu\\mock\\vnd_spbu_5days.json'
 settings_file = 'D:\\vnd_spbu\\pilot\\mu5days\\vnd_spbu_5days.json'
 #settings_file = 'C:\\Users\\nsmetanin\\Desktop\\results\\vnd_spbu_5days.json'
-with open(settings_file, 'r') as f:
+with open(settings_file, 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 

--- a/pynfb/postprocessing/mu_csp.py
+++ b/pynfb/postprocessing/mu_csp.py
@@ -18,7 +18,7 @@ mock = False
 
 
 dir_ = 'D:\mu_ica\mu_ica'
-with open(dir_ + '\\info.json', 'r') as f:
+with open(dir_ + '\\info.json', 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 subj = 0

--- a/pynfb/postprocessing/mu_experiment_extended.py
+++ b/pynfb/postprocessing/mu_experiment_extended.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
     from json import loads
     settings_file = 'D:\\vnd_spbu\\pilot\\mu5days\\vnd_spbu_5days.json'
     #settings_file = 'D:\\vnd_spbu\\mock\\vnd_spbu_5days.json'
-    with open(settings_file, 'r') as f:
+    with open(settings_file, 'r', encoding="utf-8") as f:
         settings = loads(f.read())
 
     channel = 'C3'

--- a/pynfb/postprocessing/mu_experiment_extended2.py
+++ b/pynfb/postprocessing/mu_experiment_extended2.py
@@ -181,7 +181,7 @@ if __name__ == '__main__':
 
     from json import loads
     settings_file = 'D:\\vnd_spbu\\mock\\vnd_spbu_5days.json'
-    with open(settings_file, 'r') as f:
+    with open(settings_file, 'r', encoding="utf-8") as f:
         settings = loads(f.read())
 
     channel = 'C3'

--- a/pynfb/postprocessing/mu_ica.py
+++ b/pynfb/postprocessing/mu_ica.py
@@ -18,7 +18,7 @@ mock = False
 
 
 dir_ = 'D:\mu_ica\mu_ica'
-with open(dir_ + '\\info.json', 'r') as f:
+with open(dir_ + '\\info.json', 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 subj = 0

--- a/pynfb/postprocessing/s3_what.py
+++ b/pynfb/postprocessing/s3_what.py
@@ -12,7 +12,7 @@ from IPython.display import clear_output
 from json import loads
 
 settings_file = 'C:\_data\mu5days\\vnd_spbu_5days.json'
-with open(settings_file, 'r') as f:
+with open(settings_file, 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 dir_ = settings['dir']

--- a/pynfb/postprocessing/s3_what_2.py
+++ b/pynfb/postprocessing/s3_what_2.py
@@ -12,7 +12,7 @@ from IPython.display import clear_output
 from json import loads
 
 settings_file = 'D:\\vnd_spbu\\pilot\\mu5days\\vnd_spbu_5days.json'
-with open(settings_file, 'r') as f:
+with open(settings_file, 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 dir_ = settings['dir']

--- a/pynfb/postprocessing/s3_what_kriv.py
+++ b/pynfb/postprocessing/s3_what_kriv.py
@@ -15,7 +15,7 @@ from json import loads
 from pynfb.protocols.ssd.topomap_selector_ica import ICADialog
 
 settings_file = 'C:\_NFB\old_desctop\\kriv\\vnd_spbu_5days.json'
-with open(settings_file, 'r') as f:
+with open(settings_file, 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 dir_ = settings['dir']

--- a/pynfb/postprocessing/s3_what_similar.py
+++ b/pynfb/postprocessing/s3_what_similar.py
@@ -14,7 +14,7 @@ from json import loads
 from pynfb.widgets.helpers import ch_names_to_2d_pos
 
 settings_file = 'D:\\vnd_spbu\\pilot\\mu5days\\vnd_spbu_5days.json'
-with open(settings_file, 'r') as f:
+with open(settings_file, 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 dir_ = settings['dir']

--- a/pynfb/postprocessing/whats_going_on.ipynb
+++ b/pynfb/postprocessing/whats_going_on.ipynb
@@ -26,7 +26,7 @@
     "#settings_file = 'D:\\\\vnd_spbu\\\\pilot\\\\mu5days\\\\vnd_spbu_5days.json'\n",
     "#settings_file = 'D:\\\\vnd_spbu\\\\mock\\\\vnd_spbu_5days.json'\n",
     "settings_file = 'C:\\\\Users\\\\nsmetanin\\\\Desktop\\\\results\\\\vnd_spbu_5days.json'\n",
-    "with open(settings_file, 'r') as f:\n",
+    "with open(settings_file, 'r', encoding=\"utf8\") as f:\n",
     "    settings = loads(f.read())"
    ]
   },
@@ -246,7 +246,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/pynfb/protocols/custom_filter_estimator/__init__.py
+++ b/pynfb/protocols/custom_filter_estimator/__init__.py
@@ -1,12 +1,12 @@
 from os import system
 
 if __name__ == '__main__':
-    with open('example.py', 'r') as f:
+    with open('example.py', 'r', encoding="utf-8") as f:
         get_filter_code = f.read()
 
     run_get_filter_code = ("\nfrom pynfb.serializers.hdf5 import load_h5py \ndata = 'test'\nfilter = get_filter(data)\nprint('filter saved', filter)")
 
-    with open('_run_get_filter.py', 'w') as f:
+    with open('_run_get_filter.py', 'w', encoding="utf-8") as f:
         f.write(get_filter_code + run_get_filter_code)
 
     system("\"E:\_nikolai\programs\WinPython\python-3.4.4.amd64\python\" _run_get_filter.py")

--- a/pynfb/serializers/__init__.py
+++ b/pynfb/serializers/__init__.py
@@ -21,7 +21,7 @@ def read_spatial_filter(filepath_or_str, fs, channel_labels=None, roi_label=''):
                 _filter_dict = dict(zip(names, coefs))
                 _filter = array([_filter_dict.get(label.upper(), 0) for label in channel_labels])
             else:
-                with open(filepath_or_str, 'r') as f:
+                with open(filepath_or_str, 'r', encoding="utf-8") as f:
                     lines = array([l.split() for l in f.read().splitlines()])
                 if len(lines[0]) == 1:
                     _filter = lines.astype(float).flatten()
@@ -46,7 +46,7 @@ def save_spatial_filter(file_path, filter_, channels_labels=None):
     :return:
     """
     filter_str = [val + '\n' for val in array(filter_).astype(str)]
-    with open(file_path, 'w') as f:
+    with open(file_path, 'w', encoding="utf-8") as f:
         if channels_labels is None:
             f.writelines(filter_str)
         else:

--- a/pynfb/serializers/defaults.py
+++ b/pynfb/serializers/defaults.py
@@ -75,6 +75,7 @@ vectors_defaults = OrderedDict([
             ('sFb_type', 'Baseline'),
             # ('dBand', ''),
             ('cString', ''),
+            ('bVoiceover', 0),
             ('bUseExtraMessage', 0),
             ('cString2', ''),
             ('fBlinkDurationMs', 50),

--- a/pynfb/serializers/xml_.py
+++ b/pynfb/serializers/xml_.py
@@ -52,7 +52,7 @@ def xml_file_to_odict(filename_or_str):
         return key, value
     # read and parse
     if '<NeurofeedbackSignalSpecs>' not in filename_or_str:
-        with open(filename_or_str, 'r') as f:
+        with open(filename_or_str, 'r', encoding="utf-8") as f:
             d = parse(f.read(), postprocessor=postprocessor)
     else:
         d = parse(filename_or_str, postprocessor=postprocessor)
@@ -74,7 +74,7 @@ def xml_file_to_params(filename=None):
 
 
 def params_to_xml_file(params, filename):
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding="utf-8") as f:
         f.write(params_to_xml(params))
 
 def params_to_xml(params):
@@ -102,7 +102,7 @@ def save_signal(signal, filename):
     default['fFFTWindowSize'] = signal.n_samples
     default['fSmoothingFactor'] = signal.smoothing_factor
     signal_dict = OrderedDict([('DerivedSignal', default)])
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding="utf-8") as f:
         f.write(unparse(signal_dict, pretty=True))
 
 

--- a/pynfb/settings_widget/protocols.py
+++ b/pynfb/settings_widget/protocols.py
@@ -230,6 +230,10 @@ class ProtocolDialog(QtWidgets.QDialog):
         self.message.setMaximumHeight(50)
         self.form_layout.addRow('&Message:', self.message)
 
+        # voiceover
+        self.voiceover = QtWidgets.QCheckBox()
+        self.form_layout.addRow('&Voiceover:', self.voiceover)
+
         # split record (CSP)
         self.split_checkbox = QtWidgets.QCheckBox()
         self.form_layout.addRow('&Add half time\nextra message (for CSP):', self.split_checkbox)
@@ -337,6 +341,7 @@ class ProtocolDialog(QtWidgets.QDialog):
         self.mock_dataset.setText(current_protocol['sMockSignalFileDataset'])
         self.message.setText(current_protocol['cString'])
         self.message2.setText(current_protocol['cString2'])
+        self.voiceover.setChecked(current_protocol['bVoiceover'])
         self.split_checkbox.setChecked(current_protocol['bUseExtraMessage'])
         current_index = self.reward_signal.findText(current_protocol['sRewardSignal'], QtCore.Qt.MatchFixedString)
         self.reward_signal.setCurrentIndex(current_index if current_index > -1 else 0)
@@ -386,6 +391,7 @@ class ProtocolDialog(QtWidgets.QDialog):
         self.params[current_signal_index]['sMockSignalFileDataset'] = self.mock_dataset.text()
         self.params[current_signal_index]['cString'] = self.message.toPlainText()
         self.params[current_signal_index]['cString2'] = self.message2.toPlainText()
+        self.params[current_signal_index]['bVoiceover'] = int(self.voiceover.isChecked())
         self.params[current_signal_index]['bUseExtraMessage'] = int(self.split_checkbox.isChecked())
         self.params[current_signal_index]['sRewardSignal'] = self.reward_signal.currentText()
         self.params[current_signal_index]['bShowReward'] = int(self.show_reward.isChecked())

--- a/pynfb/signals/bci.py
+++ b/pynfb/signals/bci.py
@@ -75,7 +75,7 @@ class BCISignal():
             labels = self.model.apply(chunk)
             self.current_sample = Counter(labels).most_common(1)[0][0]
         self.current_chunk = self.current_sample * np.ones(len(chunk))
-        with open("bci_current_state.pkl", "w") as fp:
+        with open("bci_current_state.pkl", "w", encoding="utf-8") as fp:
             fp.write(str(self.current_sample))
         #print(self.current_sample, type(self.current_sample))
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ install_requires = [
 
 extras_require = {
     "freeze":  [
-        "pyinstaller-hooks-contrib @ https://github.com/pyinstaller/pyinstaller-hooks-contrib/archive/465a2caccb5913ebfc64561e8055e81d73188736.zip",
         "pyinstaller",
     ]
 }

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,14 @@ install_requires = [
     "sympy",
     "mne",
     "pylsl",
-    "matplotlib==3.2.2",
+    "matplotlib",
 ]
 
 extras_require = {
-    "freeze":  ["pyinstaller==3.6"]
+    "freeze":  [
+        "pyinstaller-hooks-contrib @ https://github.com/pyinstaller/pyinstaller-hooks-contrib/archive/465a2caccb5913ebfc64561e8055e81d73188736.zip",
+        "pyinstaller",
+    ]
 }
 
 package_data = {

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ install_requires = [
     "mne",
     "pylsl",
     "matplotlib",
+    "gtts",
+    "googletrans"
 ]
 
 extras_require = {

--- a/tests/audio/convert_to_fif.py
+++ b/tests/audio/convert_to_fif.py
@@ -12,7 +12,7 @@ names_map = {'Po3': 'Fc5',
 
 
 def save_fif(record_dir, fix_names=False):
-    with open('{}\montage.info'.format(record_dir), 'r') as f:
+    with open('{}\montage.info'.format(record_dir), 'r', encoding="utf-8") as f:
         fs, *channels = f.readline().split(' ')
         fs = int(fs)
 

--- a/tests/audio/lsl_inlet.py
+++ b/tests/audio/lsl_inlet.py
@@ -51,7 +51,7 @@ class LSLInlet:
         pass
 
     def save_info(self, file):
-        with open(file, 'w') as f:
+        with open(file, 'w', encoding="utf-8") as f:
             f.write(self.info_as_xml())
 
     def info_as_xml(self):

--- a/tests/audio/play_and_record.py
+++ b/tests/audio/play_and_record.py
@@ -33,7 +33,7 @@ else:
     raise FileExistsError('Recording directory exists')
 
 # save montage
-with open('{}\montage.info'.format(record_dir), 'w') as f:
+with open('{}\montage.info'.format(record_dir), 'w', encoding="utf-8") as f:
     f.write(' '.join([str(fs)]+channels + ['timestamps']))
 
 # setup buffer

--- a/tests/bci_test/ica_reject.py
+++ b/tests/bci_test/ica_reject.py
@@ -15,7 +15,7 @@ from scipy import stats
 from pynfb.signals.bci import BCISignal
 
 dir_ = r'D:\bci_nfb_bci\bci_nfb_bci'
-with open(dir_ + '\\info.json', 'r') as f:
+with open(dir_ + '\\info.json', 'r', encoding="utf-8") as f:
     settings = loads(f.read())
 
 

--- a/tests/mitsar/alpha_p4_nfb_training.xml
+++ b/tests/mitsar/alpha_p4_nfb_training.xml
@@ -114,7 +114,7 @@
 			<fRandomOverTime>0.0</fRandomOverTime>
 			<fbSource>All</fbSource>
 			<sFb_type>Baseline</sFb_type>
-			<cString>Можно отдохнуть</cString>
+			<cString>РњРѕР¶РЅРѕ РѕС‚РґРѕС…РЅСѓС‚СЊ</cString>
 			<bUseExtraMessage>0</bUseExtraMessage>
 			<cString2></cString2>
 			<fBlinkDurationMs>50</fBlinkDurationMs>


### PR DESCRIPTION
### Changes
* As of writing (2020-10-22) pynfb works correctly on latest pip versions of matplotlib and pyinstaller;
* Pynfb now writes and reads every file in UTF-8. Some experiment files created on windows may be incompatible until re-encoded;
* Added a dedicated `run` method for launching a pynfb experiment, available to import from `pynfb.main`;
* Added a switch to enable text-to-speech voiceover of block messages;
* Fixed `lsl_generator` inlet not working on Linux.